### PR TITLE
Support symbol methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(classmethod test/cc/class_method.cc)
 add_executable(classproperty test/cc/class_property.cc)
 add_executable(classclassmethod test/cc/class_class_method.cc)
 add_executable(classmethodmultiparam test/cc/class_method_multi_param.cc)
+add_executable(symbol_method test/cc/symbol_method.cc)
 
 foreach(executable IN ITEMS 
 		# general
@@ -41,6 +42,8 @@ foreach(executable IN ITEMS
 		smartptr subclass_smartptr
 		# enums
 		emptyenum enum1 enum2
+		# symbols
+		symbol_method
 )
 	target_link_options(${executable} PUBLIC
 		-s MODULARIZE --bind

--- a/src/declaration/resolve.ts
+++ b/src/declaration/resolve.ts
@@ -70,8 +70,17 @@ const resolveMemberFunction =
     const argTypes = heap32VectorToArray(ctx.module)(argCount, rawArgTypesAddr)
     const argTypeNames = argTypes.map(id => typeIdToTypeName(ctx,id))
     const [returnType, instanceType,  ...parameterTypes] = argTypeNames
+
+    let name = readLatin1String(ctx.module)(injected.methodName)
+
+    // In embind, anything prefixed with '@@' is bound using the named symbol 'Symbol'.
+	// See https://emscripten.org/docs/api_reference/bind.h.html#_CPPv4NK6class_8functionEv
+	if (name.startsWith('@@')) {
+		name = `[Symbol.${name.substring(2)}]`
+	}
+
     return {
-        name: readLatin1String(ctx.module)(injected.methodName),
+        name,
         parameters: createParameters(ctx,parameterTypes),
         returnType
     }

--- a/test/cc/symbol_method.cc
+++ b/test/cc/symbol_method.cc
@@ -1,0 +1,15 @@
+#include <emscripten/bind.h>
+#include <string>
+
+using namespace emscripten;
+
+struct CustomObj {};
+
+EMSCRIPTEN_BINDINGS(voidfunc) {
+	class_<CustomObj>("CustomObj")
+        .constructor()
+        .function("@@iterator", optional_override([](CustomObj const& cm) {
+            // The return value doesn't matter. We only want to test the method name.
+            return val("iterator");
+        }));
+}


### PR DESCRIPTION
This PR adds support for bound functions (method) that start with `@@`. Embind converts these methods into `[Symbol.<method>]` as documented at https://emscripten.org/docs/api_reference/bind.h.html#_CPPv4NK6class_8functionEv.