### PR TITLE
Support BigInt64Array and BigUint64Array

### DIFF
--- a/src/injection/inject.ts
+++ b/src/injection/inject.ts
@@ -152,6 +152,8 @@ wrappers['_embind_register_memory_view'] =
         Uint32Array,
         Float32Array,
         Float64Array,
+        BigInt64Array,
+        BigUint64Array,
     ];
 	const type = typeMapping[dataTypeIndex];
 	registry.types[rawType] = () => type.name;


### PR DESCRIPTION
This is a simple PR that adds support for `BigInt64Array` and `BigUint64Array`. From what I see, it's required starting with Emscripten 3.1.35.